### PR TITLE
Fix compilation

### DIFF
--- a/fluidlite/src/log.rs
+++ b/fluidlite/src/log.rs
@@ -160,7 +160,7 @@ impl<F: FnMut(LogLevel, &str)> Logger for FnLogger<F> {
  */
 pub struct Log {
     levels: Vec<LogLevel>,
-    #[used]
+    #[allow(unused)]
     logger: Box<dyn Logger>,
 }
 


### PR DESCRIPTION
Fluidlite cannot be built with the latest Rust version. A previously accepted error seems to be a hard error now.

Error message:

```
error: attribute must be applied to a `static` variable
   --> /home/xxx/.cargo/registry/src/github.com-1ecc6299db9ec823/fluidlite-0.1.3/src/log.rs:163:5
    |
163 |     #[used]
    |     ^^^^^^^
```

Fix: Remove `#[used]`. I think `#[allow(unused)]` is what is intended here.